### PR TITLE
Accept String instead of String[] in SendMessage

### DIFF
--- a/MumbleSharp/Model/User.cs
+++ b/MumbleSharp/Model/User.cs
@@ -41,6 +41,12 @@ namespace MumbleSharp.Model
             _owner = owner;
             Id = id;
         }
+        
+        public void SendMessage(string message)
+        {
+            var messages = message.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
+            SendMessage(messages);
+        }
 
         public void SendMessage(string[] message)
         {


### PR DESCRIPTION
Hello,

This commit fix issue  #14.

You can test the method on [dotnetfiddle](https://dotnetfiddle.net/giXCgQ).

You can consider to use `StringSplitOptions.RemoveEmptyEntries` but I dont think it is what you need.

If you want to cover the unix world, you can replace `Environment.NewLine` with `"\r\n", "\n"`