### PR TITLE
Ability to set audio sample rate/bits/channels

### DIFF
--- a/MumbleClient/MicrophoneRecorder.cs
+++ b/MumbleClient/MicrophoneRecorder.cs
@@ -15,7 +15,7 @@ namespace MumbleClient
             _protocol = protocol;
             var sourceStream = new WaveInEvent
             {
-                WaveFormat = new WaveFormat(Constants.SAMPLE_RATE, Constants.SAMPLE_BITS, Constants.CHANNELS)
+                WaveFormat = new WaveFormat(Constants.DEFAULT_AUDIO_SAMPLE_RATE, Constants.DEFAULT_AUDIO_SAMPLE_BITS, Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
             };
             sourceStream.DataAvailable += VoiceDataAvailable;
 

--- a/MumbleClient/MumbleClient.csproj
+++ b/MumbleClient/MumbleClient.csproj
@@ -39,17 +39,18 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NAudio, Version=1.8.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NAudio.1.8.4\lib\net35\NAudio.dll</HintPath>
+    <Reference Include="NAudio, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.1.9.0\lib\net35\NAudio.dll</HintPath>
     </Reference>
-    <Reference Include="protobuf-net, Version=2.3.7.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.3.7\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/MumbleClient/packages.config
+++ b/MumbleClient/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NAudio" version="1.8.4" targetFramework="net45" />
-  <package id="protobuf-net" version="2.3.7" targetFramework="net45" />
+  <package id="NAudio" version="1.9.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.4.0" targetFramework="net45" />
 </packages>

--- a/MumbleGuiClient/Extensions/MicrophoneRecorder.cs
+++ b/MumbleGuiClient/Extensions/MicrophoneRecorder.cs
@@ -76,7 +76,7 @@ namespace MumbleGuiClient
                 sourceStream.Dispose();
             sourceStream = new WaveInEvent
             {
-                WaveFormat = new WaveFormat(Constants.SAMPLE_RATE, Constants.SAMPLE_BITS, Constants.CHANNELS)
+                WaveFormat = new WaveFormat(Constants.DEFAULT_AUDIO_SAMPLE_RATE, Constants.DEFAULT_AUDIO_SAMPLE_BITS, Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
             };
             sourceStream.BufferMilliseconds = 10;
             sourceStream.DeviceNumber = SelectedDevice;

--- a/MumbleGuiClient/Form1.cs
+++ b/MumbleGuiClient/Form1.cs
@@ -449,8 +449,10 @@ namespace MumbleGuiClient
                 tvUsers.Nodes.Clear();
             }
 
+            string srvConnectName = textBoxUserName.Text + "@" + addr + ":" + port;
+
             connection = new MumbleConnection(new IPEndPoint(Dns.GetHostAddresses(addr).First(a => a.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork), port), protocol);
-            connection.Connect(name, pass, new string[0], addr);
+            connection.Connect(name, pass, new string[0], srvConnectName);
 
             while (connection.Protocol.LocalUser == null)
             {

--- a/MumbleGuiClient/MumbleGuiClient.csproj
+++ b/MumbleGuiClient/MumbleGuiClient.csproj
@@ -32,8 +32,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NAudio, Version=1.8.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NAudio.1.8.4\lib\net35\NAudio.dll</HintPath>
+    <Reference Include="NAudio, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.1.9.0\lib\net35\NAudio.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/MumbleGuiClient/packages.config
+++ b/MumbleGuiClient/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NAudio" version="1.8.4" targetFramework="net45" />
+  <package id="NAudio" version="1.9.0" targetFramework="net45" />
 </packages>

--- a/MumbleSharp/Audio/AudioDecodingBuffer.cs
+++ b/MumbleSharp/Audio/AudioDecodingBuffer.cs
@@ -11,18 +11,18 @@ namespace MumbleSharp.Audio
     public class AudioDecodingBuffer
         : IWaveProvider
     {
-        private static readonly WaveFormat _format = new WaveFormat((int)Constants.SAMPLE_RATE, (int)Constants.SAMPLE_BITS, 1);
-        public WaveFormat WaveFormat
-        {
-            get
-            {
-                return _format;
-            }
-        }
-
+        private readonly ushort _sampleRate;
+        public WaveFormat WaveFormat { get; private set; }
         private int _decodedOffset;
         private int _decodedCount;
-        private readonly byte[] _decodedBuffer = new byte[Constants.SAMPLE_RATE * (Constants.SAMPLE_BITS / 8) * 1];
+        private readonly byte[] _decodedBuffer;
+
+        public AudioDecodingBuffer(ushort sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        {
+            WaveFormat = new WaveFormat(sampleRate, sampleBits, sampleChannels);
+            _sampleRate = sampleRate;
+            _decodedBuffer = new byte[sampleRate * (sampleBits / 8) * sampleChannels];
+        }
 
         private long _nextSequenceToDecode;
         private readonly List<BufferPacket> _encodedBuffer = new List<BufferPacket>(); 
@@ -140,7 +140,7 @@ namespace MumbleSharp.Audio
             //    _codec.Decode(null);
 
             var d = _codec.Decode(packet.Value.Data);
-            _nextSequenceToDecode = packet.Value.Sequence + d.Length / Constants.FRAME_SIZE;
+            _nextSequenceToDecode = packet.Value.Sequence + d.Length / (_sampleRate / 20);
 
             Array.Copy(d, 0, _decodedBuffer, _decodedOffset, d.Length);
             _decodedCount += d.Length;

--- a/MumbleSharp/Audio/AudioDecodingBuffer.cs
+++ b/MumbleSharp/Audio/AudioDecodingBuffer.cs
@@ -12,13 +12,21 @@ namespace MumbleSharp.Audio
         : IWaveProvider
     {
         private readonly int _sampleRate;
-        private readonly float _frameSize;
+        private readonly ushort _frameSize;
         public WaveFormat WaveFormat { get; private set; }
         private int _decodedOffset;
         private int _decodedCount;
         private readonly byte[] _decodedBuffer;
 
-        public AudioDecodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioDecodingBuffer"/> class which Buffers up encoded audio packets and provides a constant stream of sound (silence if there is no more audio to decode).
+        /// </summary>
+        /// <param name="sampleRate">The sample rate in Hertz (samples per second).</param>
+        /// <param name="sampleBits">The sample bit depth.</param>
+        /// <param name="sampleChannels">The sample channels (1 for mono, 2 for stereo).</param>
+        /// <param name="frameSize">Size of the frame in samples.</param>
+        public AudioDecodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, ushort frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             WaveFormat = new WaveFormat(sampleRate, sampleBits, sampleChannels);
             _sampleRate = sampleRate;
@@ -142,7 +150,7 @@ namespace MumbleSharp.Audio
             //    _codec.Decode(null);
 
             var d = _codec.Decode(packet.Value.Data);
-            _nextSequenceToDecode = packet.Value.Sequence + d.Length / (int)(_sampleRate / _frameSize);
+            _nextSequenceToDecode = packet.Value.Sequence + d.Length / (_sampleRate / _frameSize);
 
             Array.Copy(d, 0, _decodedBuffer, _decodedOffset, d.Length);
             _decodedCount += d.Length;

--- a/MumbleSharp/Audio/AudioDecodingBuffer.cs
+++ b/MumbleSharp/Audio/AudioDecodingBuffer.cs
@@ -12,15 +12,17 @@ namespace MumbleSharp.Audio
         : IWaveProvider
     {
         private readonly int _sampleRate;
+        private readonly float _frameSize;
         public WaveFormat WaveFormat { get; private set; }
         private int _decodedOffset;
         private int _decodedCount;
         private readonly byte[] _decodedBuffer;
 
-        public AudioDecodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public AudioDecodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             WaveFormat = new WaveFormat(sampleRate, sampleBits, sampleChannels);
             _sampleRate = sampleRate;
+            _frameSize = frameSize;
             _decodedBuffer = new byte[sampleRate * (sampleBits / 8) * sampleChannels];
         }
 
@@ -140,7 +142,7 @@ namespace MumbleSharp.Audio
             //    _codec.Decode(null);
 
             var d = _codec.Decode(packet.Value.Data);
-            _nextSequenceToDecode = packet.Value.Sequence + d.Length / (_sampleRate / 20);
+            _nextSequenceToDecode = packet.Value.Sequence + d.Length / (int)(_sampleRate / _frameSize);
 
             Array.Copy(d, 0, _decodedBuffer, _decodedOffset, d.Length);
             _decodedCount += d.Length;

--- a/MumbleSharp/Audio/AudioDecodingBuffer.cs
+++ b/MumbleSharp/Audio/AudioDecodingBuffer.cs
@@ -11,13 +11,13 @@ namespace MumbleSharp.Audio
     public class AudioDecodingBuffer
         : IWaveProvider
     {
-        private readonly ushort _sampleRate;
+        private readonly int _sampleRate;
         public WaveFormat WaveFormat { get; private set; }
         private int _decodedOffset;
         private int _decodedCount;
         private readonly byte[] _decodedBuffer;
 
-        public AudioDecodingBuffer(ushort sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public AudioDecodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
         {
             WaveFormat = new WaveFormat(sampleRate, sampleBits, sampleChannels);
             _sampleRate = sampleRate;

--- a/MumbleSharp/Audio/AudioEncodingBuffer.cs
+++ b/MumbleSharp/Audio/AudioEncodingBuffer.cs
@@ -17,9 +17,9 @@ namespace MumbleSharp.Audio
 
         private TargettedSpeech? _unencodedItem;
 
-        public AudioEncodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public AudioEncodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
-            _codecs = new CodecSet(sampleRate, sampleBits, sampleChannels);
+            _codecs = new CodecSet(sampleRate, sampleBits, sampleChannels, frameSize);
         }
 
         /// <summary>

--- a/MumbleSharp/Audio/AudioEncodingBuffer.cs
+++ b/MumbleSharp/Audio/AudioEncodingBuffer.cs
@@ -17,7 +17,7 @@ namespace MumbleSharp.Audio
 
         private TargettedSpeech? _unencodedItem;
 
-        public AudioEncodingBuffer(ushort sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public AudioEncodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
         {
             _codecs = new CodecSet(sampleRate, sampleBits, sampleChannels);
         }

--- a/MumbleSharp/Audio/AudioEncodingBuffer.cs
+++ b/MumbleSharp/Audio/AudioEncodingBuffer.cs
@@ -17,7 +17,14 @@ namespace MumbleSharp.Audio
 
         private TargettedSpeech? _unencodedItem;
 
-        public AudioEncodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AudioEncodingBuffer"/> class.
+        /// </summary>
+        /// <param name="sampleRate">The sample rate in Hertz (samples per second).</param>
+        /// <param name="sampleBits">The sample bit depth.</param>
+        /// <param name="sampleChannels">The sample channels (1 for mono, 2 for stereo).</param>
+        /// <param name="frameSize">Size of the frame in samples.</param>
+        public AudioEncodingBuffer(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, ushort frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             _codecs = new CodecSet(sampleRate, sampleBits, sampleChannels, frameSize);
         }

--- a/MumbleSharp/Audio/AudioEncodingBuffer.cs
+++ b/MumbleSharp/Audio/AudioEncodingBuffer.cs
@@ -9,13 +9,18 @@ namespace MumbleSharp.Audio
     {
         private readonly BlockingCollection<TargettedSpeech> _unencodedBuffer = new BlockingCollection<TargettedSpeech>(new ConcurrentQueue<TargettedSpeech>());
 
-        private readonly CodecSet _codecs = new CodecSet();
+        private readonly CodecSet _codecs;
 
         private SpeechTarget _target;
         private uint _targetId;
         private readonly DynamicCircularBuffer _pcmBuffer = new DynamicCircularBuffer();
 
         private TargettedSpeech? _unencodedItem;
+
+        public AudioEncodingBuffer(ushort sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        {
+            _codecs = new CodecSet(sampleRate, sampleBits, sampleChannels);
+        }
 
         /// <summary>
         /// Add some raw PCM data to the buffer to send

--- a/MumbleSharp/Audio/CodecSet.cs
+++ b/MumbleSharp/Audio/CodecSet.cs
@@ -9,10 +9,18 @@ namespace MumbleSharp.Audio
 {
     public class CodecSet
     {
-        private readonly Lazy<CeltAlphaCodec> _alpha = new Lazy<CeltAlphaCodec>();
-        private readonly Lazy<CeltBetaCodec> _beta = new Lazy<CeltBetaCodec>();
-        private readonly Lazy<SpeexCodec> _speex = new Lazy<SpeexCodec>();
-        private readonly Lazy<OpusCodec> _opus = new Lazy<OpusCodec>();
+        private readonly Lazy<CeltAlphaCodec> _alpha;
+        private readonly Lazy<CeltBetaCodec> _beta;
+        private readonly Lazy<SpeexCodec> _speex;
+        private readonly Lazy<OpusCodec> _opus;
+
+        public CodecSet(ushort sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        {
+            _alpha = new Lazy<CeltAlphaCodec>();
+            _beta = new Lazy<CeltBetaCodec>();
+            _speex = new Lazy<SpeexCodec>();
+            _opus = new Lazy<OpusCodec>(() => new OpusCodec(sampleRate, sampleBits, sampleChannels));
+        }
 
         protected internal IVoiceCodec GetCodec(SpeechCodecs codec)
         {

--- a/MumbleSharp/Audio/CodecSet.cs
+++ b/MumbleSharp/Audio/CodecSet.cs
@@ -14,7 +14,14 @@ namespace MumbleSharp.Audio
         private readonly Lazy<SpeexCodec> _speex;
         private readonly Lazy<OpusCodec> _opus;
 
-        public CodecSet(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CodecSet"/> class.
+        /// </summary>
+        /// <param name="sampleRate">The sample rate in Hertz (samples per second).</param>
+        /// <param name="sampleBits">The sample bit depth.</param>
+        /// <param name="sampleChannels">The sample channels (1 for mono, 2 for stereo).</param>
+        /// <param name="frameSize">Size of the frame in samples.</param>
+        public CodecSet(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, ushort frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             _alpha = new Lazy<CeltAlphaCodec>();
             _beta = new Lazy<CeltBetaCodec>();

--- a/MumbleSharp/Audio/CodecSet.cs
+++ b/MumbleSharp/Audio/CodecSet.cs
@@ -14,12 +14,12 @@ namespace MumbleSharp.Audio
         private readonly Lazy<SpeexCodec> _speex;
         private readonly Lazy<OpusCodec> _opus;
 
-        public CodecSet(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public CodecSet(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             _alpha = new Lazy<CeltAlphaCodec>();
             _beta = new Lazy<CeltBetaCodec>();
             _speex = new Lazy<SpeexCodec>();
-            _opus = new Lazy<OpusCodec>(() => new OpusCodec(sampleRate, sampleBits, sampleChannels));
+            _opus = new Lazy<OpusCodec>(() => new OpusCodec(sampleRate, sampleBits, sampleChannels, frameSize));
         }
 
         protected internal IVoiceCodec GetCodec(SpeechCodecs codec)

--- a/MumbleSharp/Audio/CodecSet.cs
+++ b/MumbleSharp/Audio/CodecSet.cs
@@ -14,7 +14,7 @@ namespace MumbleSharp.Audio
         private readonly Lazy<SpeexCodec> _speex;
         private readonly Lazy<OpusCodec> _opus;
 
-        public CodecSet(ushort sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public CodecSet(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte sampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
         {
             _alpha = new Lazy<CeltAlphaCodec>();
             _beta = new Lazy<CeltBetaCodec>();

--- a/MumbleSharp/Audio/Codecs/Opus/OpusCodec.cs
+++ b/MumbleSharp/Audio/Codecs/Opus/OpusCodec.cs
@@ -9,9 +9,16 @@ namespace MumbleSharp.Audio.Codecs.Opus
         private readonly OpusDecoder _decoder;
         private readonly OpusEncoder _encoder;
         private readonly int _sampleRate;
-        private readonly float _frameSize;
+        private readonly ushort _frameSize;
 
-        public OpusCodec(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte channels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpusCodec"/> class.
+        /// </summary>
+        /// <param name="sampleRate">The sample rate in Hertz (samples per second).</param>
+        /// <param name="sampleBits">The sample bit depth.</param>
+        /// <param name="sampleChannels">The sample channels (1 for mono, 2 for stereo).</param>
+        /// <param name="frameSize">Size of the frame in samples.</param>
+        public OpusCodec(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte channels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, ushort frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             _sampleRate = sampleRate;
             _frameSize = frameSize;
@@ -23,7 +30,7 @@ namespace MumbleSharp.Audio.Codecs.Opus
         {
             if (encodedData == null)
             {
-                _decoder.Decode(null, 0, 0, new byte[(int)(_sampleRate / _frameSize)], 0);
+                _decoder.Decode(null, 0, 0, new byte[_sampleRate / _frameSize], 0);
                 return null;
             }
 

--- a/MumbleSharp/Audio/Codecs/Opus/OpusCodec.cs
+++ b/MumbleSharp/Audio/Codecs/Opus/OpusCodec.cs
@@ -6,22 +6,24 @@ namespace MumbleSharp.Audio.Codecs.Opus
     public class OpusCodec
         : IVoiceCodec
     {
-        readonly OpusDecoder _decoder;
-        readonly OpusEncoder _encoder;
-        readonly int _sampleRate;
+        private readonly OpusDecoder _decoder;
+        private readonly OpusEncoder _encoder;
+        private readonly int _sampleRate;
+        private readonly float _frameSize;
 
-        public OpusCodec(int SampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte SampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte Channels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public OpusCodec(int sampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte sampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte channels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float frameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
-            _sampleRate = SampleRate;
-            _decoder = new OpusDecoder(SampleRate, Channels) { EnableForwardErrorCorrection = true };
-            _encoder = new OpusEncoder(SampleRate, Channels) { EnableForwardErrorCorrection = true };
+            _sampleRate = sampleRate;
+            _frameSize = frameSize;
+            _decoder = new OpusDecoder(sampleRate, channels) { EnableForwardErrorCorrection = true };
+            _encoder = new OpusEncoder(sampleRate, channels) { EnableForwardErrorCorrection = true };
         }
 
         public byte[] Decode(byte[] encodedData)
         {
             if (encodedData == null)
             {
-                _decoder.Decode(null, 0, 0, new byte[_sampleRate / 20], 0);
+                _decoder.Decode(null, 0, 0, new byte[(int)(_sampleRate / _frameSize)], 0);
                 return null;
             }
 

--- a/MumbleSharp/Audio/Codecs/Opus/OpusCodec.cs
+++ b/MumbleSharp/Audio/Codecs/Opus/OpusCodec.cs
@@ -6,18 +6,26 @@ namespace MumbleSharp.Audio.Codecs.Opus
     public class OpusCodec
         : IVoiceCodec
     {
-        readonly OpusDecoder _decoder = new OpusDecoder(Constants.SAMPLE_RATE, Constants.CHANNELS) { EnableForwardErrorCorrection = true };
-        readonly OpusEncoder _encoder = new OpusEncoder(Constants.SAMPLE_RATE, Constants.CHANNELS) { EnableForwardErrorCorrection = true };
+        readonly OpusDecoder _decoder;
+        readonly OpusEncoder _encoder;
+        readonly ushort _sampleRate;
+
+        public OpusCodec(ushort SampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort SampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort Channels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        {
+            _sampleRate = SampleRate;
+            _decoder = new OpusDecoder(SampleRate, Channels) { EnableForwardErrorCorrection = true };
+            _encoder = new OpusEncoder(SampleRate, Channels) { EnableForwardErrorCorrection = true };
+        }
 
         public byte[] Decode(byte[] encodedData)
         {
             if (encodedData == null)
             {
-                _decoder.Decode(null, 0, 0, new byte[Constants.FRAME_SIZE], 0);
+                _decoder.Decode(null, 0, 0, new byte[_sampleRate / 20], 0);
                 return null;
             }
 
-            int samples = OpusDecoder.GetSamples(encodedData, 0, encodedData.Length, Constants.SAMPLE_RATE);
+            int samples = OpusDecoder.GetSamples(encodedData, 0, encodedData.Length, _sampleRate);
             if (samples < 1)
                 return null;
 

--- a/MumbleSharp/Audio/Codecs/Opus/OpusCodec.cs
+++ b/MumbleSharp/Audio/Codecs/Opus/OpusCodec.cs
@@ -8,9 +8,9 @@ namespace MumbleSharp.Audio.Codecs.Opus
     {
         readonly OpusDecoder _decoder;
         readonly OpusEncoder _encoder;
-        readonly ushort _sampleRate;
+        readonly int _sampleRate;
 
-        public OpusCodec(ushort SampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort SampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort Channels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public OpusCodec(int SampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte SampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte Channels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
         {
             _sampleRate = SampleRate;
             _decoder = new OpusDecoder(SampleRate, Channels) { EnableForwardErrorCorrection = true };

--- a/MumbleSharp/Audio/Codecs/Opus/OpusEncoder.cs
+++ b/MumbleSharp/Audio/Codecs/Opus/OpusEncoder.cs
@@ -69,7 +69,7 @@ namespace MumbleSharp.Audio.Codecs.Opus
                 throw new ArgumentOutOfRangeException("srcChannelCount");
 
             IntPtr error;
-            var encoder = NativeMethods.opus_encoder_create(srcSamplingRate, srcChannelCount, 2048, out error);
+            var encoder = NativeMethods.opus_encoder_create(srcSamplingRate, srcChannelCount, (int)Application.Voip, out error);
             if ((NativeMethods.OpusErrors)error != NativeMethods.OpusErrors.Ok)
             {
                 throw new Exception("Exception occured while creating encoder");

--- a/MumbleSharp/Audio/Codecs/Opus/OpusEncoder.cs
+++ b/MumbleSharp/Audio/Codecs/Opus/OpusEncoder.cs
@@ -47,7 +47,7 @@ namespace MumbleSharp.Audio.Codecs.Opus
         /// <summary>
         /// Permitted frame sizes in ms.
         /// </summary>
-        private readonly float[] _permittedFrameSizes = {
+        private readonly float[] _permittedFrameSizesInMillisec = {
             2.5f, 5, 10,
             20, 40, 60
         };
@@ -79,9 +79,9 @@ namespace MumbleSharp.Audio.Codecs.Opus
             const int BIT_DEPTH = 16;
             _sampleSize = SampleSize(BIT_DEPTH, srcChannelCount);
 
-            PermittedFrameSizes = new int[_permittedFrameSizes.Length];
-            for (var i = 0; i < _permittedFrameSizes.Length; i++)
-                PermittedFrameSizes[i] = (int)(srcSamplingRate / 1000f * _permittedFrameSizes[i]);
+            PermittedFrameSizes = new int[_permittedFrameSizesInMillisec.Length];
+            for (var i = 0; i < _permittedFrameSizesInMillisec.Length; i++)
+                PermittedFrameSizes[i] = (int)(srcSamplingRate / 1000f * _permittedFrameSizesInMillisec[i]);
         }
 
         private static int SampleSize(int bitDepth, int channelCount)

--- a/MumbleSharp/BasicMumbleProtocol.cs
+++ b/MumbleSharp/BasicMumbleProtocol.cs
@@ -61,11 +61,13 @@ namespace MumbleSharp
         private int _audioSampleRate;
         private byte _audioSampleBits;
         private byte _audioSampleChannels;
-        public BasicMumbleProtocol(int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        private float _audioFrameSize;
+        public BasicMumbleProtocol(int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float audioFrameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             _audioSampleRate = audioSampleRate;
             _audioSampleBits = audioSampleBits;
             _audioSampleChannels = audioSampleChannels;
+            _audioFrameSize = audioFrameSize;
         }
 
         /// <summary>
@@ -260,7 +262,7 @@ namespace MumbleSharp
             //Get the local user
             LocalUser = UserDictionary[serverSync.Session];
 
-            _encodingBuffer = new AudioEncodingBuffer(_audioSampleRate, _audioSampleBits, _audioSampleChannels);
+            _encodingBuffer = new AudioEncodingBuffer(_audioSampleRate, _audioSampleBits, _audioSampleChannels, _audioFrameSize);
             _encodingThread.Start();
 
             ReceivedServerSync = true;

--- a/MumbleSharp/BasicMumbleProtocol.cs
+++ b/MumbleSharp/BasicMumbleProtocol.cs
@@ -58,9 +58,14 @@ namespace MumbleSharp
 
         public bool IsEncodingThreadRunning { get; set; }
 
-        public BasicMumbleProtocol()
+        private ushort _audioSampleRate;
+        private ushort _audioSampleBits;
+        private ushort _audioSampleChannels;
+        public BasicMumbleProtocol(ushort audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
         {
-            
+            _audioSampleRate = audioSampleRate;
+            _audioSampleBits = audioSampleBits;
+            _audioSampleChannels = audioSampleChannels;
         }
 
         /// <summary>
@@ -182,7 +187,7 @@ namespace MumbleSharp
                 bool added = false;
                 User user = UserDictionary.AddOrUpdate(userState.Session, i => {
                     added = true;
-                    return new User(this, userState.Session);
+                    return new User(this, userState.Session, _audioSampleRate, _audioSampleBits, _audioSampleChannels);
                 }, (i, u) => u);
 
                 if (userState.ShouldSerializeSelfDeaf())

--- a/MumbleSharp/BasicMumbleProtocol.cs
+++ b/MumbleSharp/BasicMumbleProtocol.cs
@@ -260,7 +260,7 @@ namespace MumbleSharp
             //Get the local user
             LocalUser = UserDictionary[serverSync.Session];
 
-            _encodingBuffer = new AudioEncodingBuffer();
+            _encodingBuffer = new AudioEncodingBuffer(_audioSampleRate, _audioSampleBits, _audioSampleChannels);
             _encodingThread.Start();
 
             ReceivedServerSync = true;

--- a/MumbleSharp/BasicMumbleProtocol.cs
+++ b/MumbleSharp/BasicMumbleProtocol.cs
@@ -58,10 +58,10 @@ namespace MumbleSharp
 
         public bool IsEncodingThreadRunning { get; set; }
 
-        private ushort _audioSampleRate;
-        private ushort _audioSampleBits;
-        private ushort _audioSampleChannels;
-        public BasicMumbleProtocol(ushort audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        private int _audioSampleRate;
+        private byte _audioSampleBits;
+        private byte _audioSampleChannels;
+        public BasicMumbleProtocol(int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
         {
             _audioSampleRate = audioSampleRate;
             _audioSampleBits = audioSampleBits;

--- a/MumbleSharp/BasicMumbleProtocol.cs
+++ b/MumbleSharp/BasicMumbleProtocol.cs
@@ -61,8 +61,16 @@ namespace MumbleSharp
         private int _audioSampleRate;
         private byte _audioSampleBits;
         private byte _audioSampleChannels;
-        private float _audioFrameSize;
-        public BasicMumbleProtocol(int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float audioFrameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
+        private ushort _audioFrameSize;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BasicMumbleProtocol"/> class.
+        /// </summary>
+        /// <param name="audioSampleRate">The sample rate in Hertz (samples per second).</param>
+        /// <param name="audioSampleBits">The sample bit depth.</param>
+        /// <param name="audioSampleChannels">The sample channels (1 for mono, 2 for stereo).</param>
+        /// <param name="audioFrameSize">Size of the frame in samples.</param>
+        public BasicMumbleProtocol(int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, ushort audioFrameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             _audioSampleRate = audioSampleRate;
             _audioSampleBits = audioSampleBits;

--- a/MumbleSharp/Constants.cs
+++ b/MumbleSharp/Constants.cs
@@ -6,6 +6,6 @@ namespace MumbleSharp
         public const int DEFAULT_AUDIO_SAMPLE_RATE = 48000;
         public const byte DEFAULT_AUDIO_SAMPLE_BITS = 16;
         public const byte DEFAULT_AUDIO_SAMPLE_CHANNELS = 1;
-        public const byte DEFAULT_AUDIO_FRAME_SIZE = 20;
+        public const ushort DEFAULT_AUDIO_FRAME_SIZE = 20;
     }
 }

--- a/MumbleSharp/Constants.cs
+++ b/MumbleSharp/Constants.cs
@@ -6,6 +6,6 @@ namespace MumbleSharp
         public const int DEFAULT_AUDIO_SAMPLE_RATE = 48000;
         public const byte DEFAULT_AUDIO_SAMPLE_BITS = 16;
         public const byte DEFAULT_AUDIO_SAMPLE_CHANNELS = 1;
-        public const ushort DEFAULT_AUDIO_FRAME_SIZE = 20;
+        public const ushort DEFAULT_AUDIO_FRAME_SIZE = 960;
     }
 }

--- a/MumbleSharp/Constants.cs
+++ b/MumbleSharp/Constants.cs
@@ -3,8 +3,8 @@ namespace MumbleSharp
 {
     public static class Constants
     {
-        public const ushort DEFAULT_AUDIO_SAMPLE_RATE = 48000;
-        public const ushort DEFAULT_AUDIO_SAMPLE_BITS = 16;
-        public const ushort DEFAULT_AUDIO_SAMPLE_CHANNELS = 1;
+        public const int DEFAULT_AUDIO_SAMPLE_RATE = 48000;
+        public const byte DEFAULT_AUDIO_SAMPLE_BITS = 16;
+        public const byte DEFAULT_AUDIO_SAMPLE_CHANNELS = 1;
     }
 }

--- a/MumbleSharp/Constants.cs
+++ b/MumbleSharp/Constants.cs
@@ -3,9 +3,8 @@ namespace MumbleSharp
 {
     public static class Constants
     {
-        public const int SAMPLE_RATE = 48000;
-        public const int FRAME_SIZE = SAMPLE_RATE / 100;
-        public const int SAMPLE_BITS = 16;
-        public const int CHANNELS = 1;
+        public const ushort DEFAULT_AUDIO_SAMPLE_RATE = 48000;
+        public const ushort DEFAULT_AUDIO_SAMPLE_BITS = 16;
+        public const ushort DEFAULT_AUDIO_SAMPLE_CHANNELS = 1;
     }
 }

--- a/MumbleSharp/Constants.cs
+++ b/MumbleSharp/Constants.cs
@@ -6,5 +6,6 @@ namespace MumbleSharp
         public const int DEFAULT_AUDIO_SAMPLE_RATE = 48000;
         public const byte DEFAULT_AUDIO_SAMPLE_BITS = 16;
         public const byte DEFAULT_AUDIO_SAMPLE_CHANNELS = 1;
+        public const byte DEFAULT_AUDIO_FRAME_SIZE = 20;
     }
 }

--- a/MumbleSharp/Model/User.cs
+++ b/MumbleSharp/Model/User.cs
@@ -39,7 +39,14 @@ namespace MumbleSharp.Model
 
         private readonly CodecSet _codecs;
 
-        public User(IMumbleProtocol owner, uint id, int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float audioFrameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
+        /// <summary>Initializes a new instance of the <see cref="User"/> class.</summary>
+        /// <param name="owner">The mumble protocol used by the User to communicate.</param>
+        /// <param name="id">The id of the user.</param>
+        /// <param name="audioSampleRate">The sample rate in Hertz (samples per second).</param>
+        /// <param name="audioSampleBits">The sample bit depth.</param>
+        /// <param name="audioSampleChannels">The sample channels (1 for mono, 2 for stereo).</param>
+        /// <param name="audioFrameSize">Size of the frame in samples.</param>
+        public User(IMumbleProtocol owner, uint id, int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, ushort audioFrameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
             _codecs = new CodecSet(audioSampleRate, audioSampleBits, audioSampleChannels, audioFrameSize);
             _buffer = new AudioDecodingBuffer(audioSampleRate, audioSampleBits, audioSampleChannels, audioFrameSize);

--- a/MumbleSharp/Model/User.cs
+++ b/MumbleSharp/Model/User.cs
@@ -39,7 +39,7 @@ namespace MumbleSharp.Model
 
         private readonly CodecSet _codecs;
 
-        public User(IMumbleProtocol owner, uint id, ushort audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public User(IMumbleProtocol owner, uint id, int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
         {
             _codecs = new CodecSet(audioSampleRate, audioSampleBits, audioSampleChannels);
             _buffer = new AudioDecodingBuffer(audioSampleRate, audioSampleBits, audioSampleChannels);

--- a/MumbleSharp/Model/User.cs
+++ b/MumbleSharp/Model/User.cs
@@ -13,7 +13,6 @@ namespace MumbleSharp.Model
         private readonly IMumbleProtocol _owner;
 
         public UInt32 Id { get; private set; }
-        public UInt32 ChannelId { get; set; }
         public string Name { get; set; }
         public string Comment { get; set; }
         public bool Deaf { get; set; }
@@ -80,12 +79,10 @@ namespace MumbleSharp.Model
             if (_channel == channel)
                 return;
 
-            this.ChannelId = channel.Id;
-
             UserState userstate = new UserState()
             {
                 Actor = _owner.LocalUser.Id,
-                ChannelId = this.ChannelId
+                ChannelId = channel.Id
             };
 
             if (this.Id != _owner.LocalUser.Id)

--- a/MumbleSharp/Model/User.cs
+++ b/MumbleSharp/Model/User.cs
@@ -39,10 +39,10 @@ namespace MumbleSharp.Model
 
         private readonly CodecSet _codecs;
 
-        public User(IMumbleProtocol owner, uint id, int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
+        public User(IMumbleProtocol owner, uint id, int audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, byte audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, byte audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS, float audioFrameSize = Constants.DEFAULT_AUDIO_FRAME_SIZE)
         {
-            _codecs = new CodecSet(audioSampleRate, audioSampleBits, audioSampleChannels);
-            _buffer = new AudioDecodingBuffer(audioSampleRate, audioSampleBits, audioSampleChannels);
+            _codecs = new CodecSet(audioSampleRate, audioSampleBits, audioSampleChannels, audioFrameSize);
+            _buffer = new AudioDecodingBuffer(audioSampleRate, audioSampleBits, audioSampleChannels, audioFrameSize);
             _owner = owner;
             Id = id;
         }

--- a/MumbleSharp/Model/User.cs
+++ b/MumbleSharp/Model/User.cs
@@ -37,10 +37,12 @@ namespace MumbleSharp.Model
             }
         }
 
-        private readonly CodecSet _codecs = new CodecSet();
+        private readonly CodecSet _codecs;
 
-        public User(IMumbleProtocol owner, uint id)
+        public User(IMumbleProtocol owner, uint id, ushort audioSampleRate = Constants.DEFAULT_AUDIO_SAMPLE_RATE, ushort audioSampleBits = Constants.DEFAULT_AUDIO_SAMPLE_BITS, ushort audioSampleChannels = Constants.DEFAULT_AUDIO_SAMPLE_CHANNELS)
         {
+            _codecs = new CodecSet(audioSampleRate, audioSampleBits, audioSampleChannels);
+            _buffer = new AudioDecodingBuffer(audioSampleRate, audioSampleBits, audioSampleChannels);
             _owner = owner;
             Id = id;
         }
@@ -146,7 +148,7 @@ namespace MumbleSharp.Model
             return other.Id == Id;
         }
 
-        private readonly AudioDecodingBuffer _buffer = new AudioDecodingBuffer();
+        private readonly AudioDecodingBuffer _buffer;
         public IWaveProvider Voice
         {
             get

--- a/MumbleSharp/MumbleSharp.csproj
+++ b/MumbleSharp/MumbleSharp.csproj
@@ -51,6 +51,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/MumbleSharp/MumbleSharp.csproj
+++ b/MumbleSharp/MumbleSharp.csproj
@@ -43,14 +43,8 @@
     </ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NAudio, Version=1.8.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\NAudio.1.8.4\lib\net35\NAudio.dll</HintPath>
-    </Reference>
     <Reference Include="NSpeex">
       <HintPath>..\Dependencies\NSpeex v1.1.1\lib\NSpeex.dll</HintPath>
-    </Reference>
-    <Reference Include="protobuf-net, Version=2.3.7.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.3.7\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/MumbleSharp/MumbleSharp.csproj
+++ b/MumbleSharp/MumbleSharp.csproj
@@ -43,15 +43,20 @@
     </ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="NAudio, Version=1.9.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\NAudio.1.9.0\lib\net35\NAudio.dll</HintPath>
+    </Reference>
     <Reference Include="NSpeex">
       <HintPath>..\Dependencies\NSpeex v1.1.1\lib\NSpeex.dll</HintPath>
+    </Reference>
+    <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
-    <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/MumbleSharp/packages.config
+++ b/MumbleSharp/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NAudio" version="1.8.4" targetFramework="net45" />
-  <package id="protobuf-net" version="2.3.7" targetFramework="net45" />
+  <package id="NAudio" version="1.9.0" targetFramework="net45" />
+  <package id="protobuf-net" version="2.4.0" targetFramework="net45" />
 </packages>

--- a/MumbleSharpTest/MumbleSharpTest.csproj
+++ b/MumbleSharpTest/MumbleSharpTest.csproj
@@ -43,8 +43,8 @@
     <Reference Include="NSpeex">
       <HintPath>..\Dependencies\NSpeex v1.1.1\lib\NSpeex.dll</HintPath>
     </Reference>
-    <Reference Include="protobuf-net, Version=2.3.7.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
-      <HintPath>..\packages\protobuf-net.2.3.7\lib\net40\protobuf-net.dll</HintPath>
+    <Reference Include="protobuf-net, Version=2.4.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
+      <HintPath>..\packages\protobuf-net.2.4.0\lib\net40\protobuf-net.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />

--- a/MumbleSharpTest/packages.config
+++ b/MumbleSharpTest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="protobuf-net" version="2.3.7" targetFramework="net461" />
+  <package id="protobuf-net" version="2.4.0" targetFramework="net461" />
 </packages>


### PR DESCRIPTION
Implements martindevans#42

I have chosen to avoid breaking change therefore each method has the sample rate/bits/channels as optional parameters where the defaults are the constants.

Developers should only need to instantiate a BasicMumbleProtocol and possibly set those parameters here.